### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/version-validation.yml
+++ b/.github/workflows/version-validation.yml
@@ -1,4 +1,6 @@
 name: Version Validation
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/nnegi88/spring-boot-error-monitor-starter/security/code-scanning/2](https://github.com/nnegi88/spring-boot-error-monitor-starter/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Since the workflow only reads the repository's contents and does not perform any write operations, we will set `contents: read`. This ensures the workflow adheres to the principle of least privilege.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
