### PR TITLE
Potential fix for code scanning alert no. 3: Cross-site scripting

### DIFF
--- a/spring-boot-error-monitor-demo/src/main/java/com/nnegi88/errormonitor/demo/controller/DemoErrorController.java
+++ b/spring-boot-error-monitor-demo/src/main/java/com/nnegi88/errormonitor/demo/controller/DemoErrorController.java
@@ -2,6 +2,7 @@ package com.nnegi88.errormonitor.demo.controller;
 
 import com.nnegi88.errormonitor.demo.exception.CustomExceptions.*;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.HtmlUtils;
 
 import java.util.Map;
 import java.util.Random;
@@ -36,7 +37,7 @@ public class DemoErrorController {
         if (value == null || value.isEmpty()) {
             throw new IllegalArgumentException("Value parameter cannot be null or empty");
         }
-        return "Value: " + value;
+        return "Value: " + HtmlUtils.htmlEscape(value);
     }
     
     @GetMapping("/product-not-found/{id}")


### PR DESCRIPTION
Potential fix for [https://github.com/nnegi88/spring-boot-error-monitor-starter/security/code-scanning/3](https://github.com/nnegi88/spring-boot-error-monitor-starter/security/code-scanning/3)

To fix the issue, the user-provided `value` parameter should be sanitized or encoded before being included in the response. The best approach is to use a library or framework-provided method for HTML encoding to ensure that any special characters in the input are safely escaped. In the context of Spring Boot, the `HtmlUtils.htmlEscape` method from the `org.springframework.web.util.HtmlUtils` class can be used to encode the `value` parameter.

The fix involves:
1. Importing `org.springframework.web.util.HtmlUtils`.
2. Using `HtmlUtils.htmlEscape(value)` to encode the `value` parameter before including it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
