### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,5 +1,8 @@
 name: Test Build (No Deployment)
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/nnegi88/spring-boot-error-monitor-starter/security/code-scanning/1](https://github.com/nnegi88/spring-boot-error-monitor-starter/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will explicitly define the permissions required for the workflow, limiting the `GITHUB_TOKEN` to the least privileges necessary. Since the workflow does not perform any write operations, the `contents: read` permission is sufficient. This change ensures that the workflow adheres to the principle of least privilege and mitigates potential security risks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
